### PR TITLE
성능 향상 - 병목 지점을 찾아 RPS를 향상시킵니다.

### DIFF
--- a/coupon-api/src/main/java/com/example/couponapi/controller/CouponIssueController.java
+++ b/coupon-api/src/main/java/com/example/couponapi/controller/CouponIssueController.java
@@ -22,9 +22,15 @@ public class CouponIssueController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/issue/async")
-    public ResponseEntity<Void> asyncIssue(@RequestBody CouponIssueRequestDto issueRequest) {
-        couponIssueRequestService.asyncIssueRequest(issueRequest);
+    @PostMapping("/issue/async/v1")
+    public ResponseEntity<Void> asyncIssueV1(@RequestBody CouponIssueRequestDto issueRequest) {
+        couponIssueRequestService.asyncIssueRequestV1(issueRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/issue/async/v2")
+    public ResponseEntity<Void> asyncIssueV2(@RequestBody CouponIssueRequestDto issueRequest) {
+        couponIssueRequestService.asyncIssueRequestV2(issueRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/coupon-api/src/main/java/com/example/couponapi/service/CouponIssueRequestService.java
+++ b/coupon-api/src/main/java/com/example/couponapi/service/CouponIssueRequestService.java
@@ -3,6 +3,7 @@ package com.example.couponapi.service;
 import com.example.couponapi.dto.CouponIssueRequestDto;
 import com.example.couponcore.component.DistributeLockExecutor;
 import com.example.couponcore.service.AsyncCouponIssueServiceV1;
+import com.example.couponcore.service.AsyncCouponIssueServiceV2;
 import com.example.couponcore.service.CouponIssueService;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -17,6 +18,7 @@ public class CouponIssueRequestService {
 
     private final CouponIssueService couponIssueService;
     private final AsyncCouponIssueServiceV1 asyncCouponIssueServiceV1;
+    private final AsyncCouponIssueServiceV2 asyncCouponIssueServiceV2;
     private final DistributeLockExecutor distributeLockExecutor;
     private final Logger log = LoggerFactory.getLogger(this.getClass().getSimpleName());
 
@@ -27,8 +29,13 @@ public class CouponIssueRequestService {
         log.info("쿠폰 발급 완료. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
     }
 
-    public void asyncIssueRequest(CouponIssueRequestDto requestDto) {
+    public void asyncIssueRequestV1(CouponIssueRequestDto requestDto) {
         asyncCouponIssueServiceV1.issue(requestDto.couponId(), requestDto.userId());
+        log.info("쿠폰 발급 완료. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
+    }
+
+    public void asyncIssueRequestV2(CouponIssueRequestDto requestDto) {
+        asyncCouponIssueServiceV2.issue(requestDto.couponId(), requestDto.userId());
         log.info("쿠폰 발급 완료. couponId: %s, userId: %s".formatted(requestDto.couponId(), requestDto.userId()));
     }
 }

--- a/coupon-core/src/main/java/com/example/couponcore/repository/redis/CouponIssueRequestCode.java
+++ b/coupon-core/src/main/java/com/example/couponcore/repository/redis/CouponIssueRequestCode.java
@@ -1,0 +1,34 @@
+package com.example.couponcore.repository.redis;
+
+import com.example.couponcore.exception.ErrorCode;
+import com.example.couponcore.exception.common.BaseException;
+import com.example.couponcore.exception.common.ConflictException;
+import com.example.couponcore.exception.custom.CouponIssueException;
+
+public enum CouponIssueRequestCode {
+    SUCCESS(1),
+    DUPLICATED_COUPON_ISSUE(2),
+    INVALID_COUPON_ISSUE_QUANTITY(3);
+
+    CouponIssueRequestCode(int code) {
+
+    }
+
+    public static CouponIssueRequestCode find(String code) {
+        int codeValue = Integer.parseInt(code);
+        if (codeValue == 1) return SUCCESS;
+        if (codeValue == 2) return DUPLICATED_COUPON_ISSUE;
+        if (codeValue == 3) return INVALID_COUPON_ISSUE_QUANTITY;
+
+        throw new BaseException(400, "존재하지 않는 코드입니다.");
+    }
+
+    public static void checkRequestResult(CouponIssueRequestCode code) {
+        if (code == INVALID_COUPON_ISSUE_QUANTITY) {
+            throw new CouponIssueException(ErrorCode.INVALID_COUPON_QUANTITY, "발급 가능한 수량을 초과했습니다.");
+        }
+        if (code == DUPLICATED_COUPON_ISSUE) {
+            throw new ConflictException("이미 발급 요청된 쿠폰입니다.");
+        }
+    }
+}

--- a/coupon-core/src/main/java/com/example/couponcore/repository/redis/RedisRepository.java
+++ b/coupon-core/src/main/java/com/example/couponcore/repository/redis/RedisRepository.java
@@ -1,14 +1,27 @@
 package com.example.couponcore.repository.redis;
 
+import com.example.couponcore.exception.common.BaseException;
+import com.example.couponcore.repository.redis.dto.CouponIssueRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.couponcore.util.CouponRedisUtils.getIssueRequestKey;
+import static com.example.couponcore.util.CouponRedisUtils.getQueueKey;
 
 @Repository
 @RequiredArgsConstructor
 public class RedisRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private RedisScript<String> issueScript = issueRequestScript();
+    private final String issueRequestQueueKey = getQueueKey();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public Boolean zAdd(String key, String value, double score) {
         return redisTemplate.opsForZSet().addIfAbsent(key, value, score);
@@ -28,5 +41,41 @@ public class RedisRepository {
 
     public Long rPush(String key, String value) {
         return redisTemplate.opsForList().rightPush(key, value);
+    }
+
+    public void issueRequest(long couponId, long userId, int totalIssueQuantity) {
+        String issueRequestKey = getIssueRequestKey(couponId);
+        CouponIssueRequest couponIssueRequest = new CouponIssueRequest(couponId, userId);
+        try {
+            String code = redisTemplate.execute(
+                    issueScript,
+                    List.of(issueRequestKey, issueRequestQueueKey),
+                    String.valueOf(userId),
+                    String.valueOf(totalIssueQuantity),
+                    objectMapper.writeValueAsString(couponIssueRequest)
+            );
+            // validation 진행
+            CouponIssueRequestCode.checkRequestResult(CouponIssueRequestCode.find(code));
+
+        } catch (JsonProcessingException e) {
+            throw new BaseException(400, e.getMessage());
+        }
+    }
+
+    public RedisScript<String> issueRequestScript() {
+        String script = """
+                if redis.call('SISMEMBER', KEYS[1], ARGV[1]) == 1 then
+                    return '2'
+                end
+                   
+                if tonumber(ARGV[2]) > redis.call('SCARD', KEYS[1]) then
+                    redis.call('SADD', KEYS[1], ARGV[1])
+                    redis.call('RPUSH', KEYS[2], ARGV[3])
+                    return '1'
+                end
+                
+                return '3'    
+                """;
+        return RedisScript.of(script, String.class);
     }
 }

--- a/coupon-core/src/main/java/com/example/couponcore/service/AsyncCouponIssueServiceV2.java
+++ b/coupon-core/src/main/java/com/example/couponcore/service/AsyncCouponIssueServiceV2.java
@@ -1,0 +1,29 @@
+package com.example.couponcore.service;
+
+import com.example.couponcore.component.DistributeLockExecutor;
+import com.example.couponcore.repository.redis.RedisRepository;
+import com.example.couponcore.repository.redis.dto.CouponRedisEntity;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AsyncCouponIssueServiceV2 {
+
+    private final RedisRepository redisRepository;
+    private final RedisCouponIssueService redisCouponIssueService;
+    private final DistributeLockExecutor distributeLockExecutor;
+    private final CouponCacheService couponCacheService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public void issue(long couponId, long userId) {
+        CouponRedisEntity coupon = couponCacheService.getCouponCache(couponId);
+        coupon.checkIssuableCoupon();
+        issueRequest(couponId, userId);
+    }
+
+    private void issueRequest(long couponId, long userId) {
+
+    }
+}

--- a/coupon-core/src/main/java/com/example/couponcore/service/AsyncCouponIssueServiceV2.java
+++ b/coupon-core/src/main/java/com/example/couponcore/service/AsyncCouponIssueServiceV2.java
@@ -1,9 +1,7 @@
 package com.example.couponcore.service;
 
-import com.example.couponcore.component.DistributeLockExecutor;
 import com.example.couponcore.repository.redis.RedisRepository;
 import com.example.couponcore.repository.redis.dto.CouponRedisEntity;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,18 +10,18 @@ import org.springframework.stereotype.Service;
 public class AsyncCouponIssueServiceV2 {
 
     private final RedisRepository redisRepository;
-    private final RedisCouponIssueService redisCouponIssueService;
-    private final DistributeLockExecutor distributeLockExecutor;
     private final CouponCacheService couponCacheService;
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     public void issue(long couponId, long userId) {
         CouponRedisEntity coupon = couponCacheService.getCouponCache(couponId);
         coupon.checkIssuableCoupon();
-        issueRequest(couponId, userId);
+        issueRequest(couponId, userId, coupon.totalQuantity());
     }
 
-    private void issueRequest(long couponId, long userId) {
-
+    private void issueRequest(long couponId, long userId, Integer totalIssueQuantity) {
+        if (totalIssueQuantity == null) {
+            redisRepository.issueRequest(couponId, userId, Integer.MAX_VALUE);
+        }
+        redisRepository.issueRequest(couponId, userId, totalIssueQuantity);
     }
 }

--- a/coupon-core/src/main/java/com/example/couponcore/service/RedisCouponIssueService.java
+++ b/coupon-core/src/main/java/com/example/couponcore/service/RedisCouponIssueService.java
@@ -1,6 +1,9 @@
 package com.example.couponcore.service;
 
+import com.example.couponcore.exception.common.BaseException;
+import com.example.couponcore.exception.common.ConflictException;
 import com.example.couponcore.repository.redis.RedisRepository;
+import com.example.couponcore.repository.redis.dto.CouponRedisEntity;
 import com.example.couponcore.util.CouponRedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,6 +13,15 @@ import org.springframework.stereotype.Service;
 public class RedisCouponIssueService {
 
     private final RedisRepository redisRepository;
+
+    public void checkCouponIssueQuantity(CouponRedisEntity coupon, long userId) {
+        if (!availableUserIssueQuantity(coupon.id(), userId)) {
+            throw new ConflictException("이미 발급된 쿠폰입니다.");
+        }
+        if (!availableTotalIssueQuantity(coupon.totalQuantity(), coupon.id())) {
+            throw new BaseException(400, "발급 가능한 수량을 초과합니다. couponId : %s, userId : %s".formatted(coupon.id(), userId));
+        }
+    }
 
     public boolean availableTotalIssueQuantity(Integer totalQuantity, long couponId) {
         if (totalQuantity == null) {

--- a/coupon-core/src/test/java/com/example/couponcore/service/AsyncCouponIssueServiceV2Test.java
+++ b/coupon-core/src/test/java/com/example/couponcore/service/AsyncCouponIssueServiceV2Test.java
@@ -1,0 +1,102 @@
+package com.example.couponcore.service;
+
+import com.example.couponcore.config.TestConfig;
+import com.example.couponcore.exception.ErrorCode;
+import com.example.couponcore.exception.common.BaseException;
+import com.example.couponcore.exception.common.DataNotFoundException;
+import com.example.couponcore.exception.custom.CouponIssueException;
+import com.example.couponcore.model.Coupon;
+import com.example.couponcore.model.CouponType;
+import com.example.couponcore.repository.mysql.CouponJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.example.couponcore.util.CouponRedisUtils.getIssueRequestKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AsyncCouponIssueServiceV2Test extends TestConfig {
+    @Autowired
+    AsyncCouponIssueServiceV2 service;
+
+    @Autowired
+    RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    CouponJpaRepository couponJpaRepository;
+
+    @BeforeEach
+    void clear() {
+        Set<String> redisKeys = redisTemplate.keys("*");
+        redisTemplate.delete(redisKeys);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 쿠폰정책이 존재하지 않는다먄 예외 반환")
+    void issueCoupon1() {
+        long couponId = 1;
+        long userId = 1;
+
+        DataNotFoundException exception = assertThrows(DataNotFoundException.class, () ->
+                service.issue(couponId, userId));
+        assertEquals(exception.getCode(), 404);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 발급 가능 수량이 존재하지 않는다면 예외 반환")
+    void issueCoupon2() {
+        // given
+        long userId = 1000;
+
+        Coupon coupon = Coupon.builder()
+                .type(CouponType.FIRST_COME_FIRST_SERVED)
+                .name("선착순 쿠폰 A")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .issueStartDate(LocalDateTime.now().minusDays(1))
+                .issueEndDate(LocalDateTime.now().plusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+
+        IntStream.range(0, 10).forEach(idx -> {
+            redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(idx));
+        });
+
+        // when & then
+        CouponIssueException exception = assertThrows(CouponIssueException.class, () -> {
+            service.issue(coupon.getId(), userId);
+        });
+        assertEquals(exception.getErrorCode(), ErrorCode.INVALID_COUPON_QUANTITY);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발급 - 발급 기간이 아닌 경우 예외 반환")
+    void issueCoupon3() {
+        // given
+        long userId = 1;
+
+        Coupon coupon = Coupon.builder()
+                .type(CouponType.FIRST_COME_FIRST_SERVED)
+                .name("선착순 쿠폰 A")
+                .totalQuantity(10)
+                .issuedQuantity(0)
+                .issueStartDate(LocalDateTime.now().minusDays(3))
+                .issueEndDate(LocalDateTime.now().minusDays(1))
+                .build();
+        couponJpaRepository.save(coupon);
+        redisTemplate.opsForSet().add(getIssueRequestKey(coupon.getId()), String.valueOf(userId));
+
+        // when & then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            service.issue(coupon.getId(), userId);
+        });
+        assertEquals(exception.getCode(), 400);
+    }
+}

--- a/load-test/docker-compose.yml
+++ b/load-test/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       - "8089:8089"
     volumes:
       - ./:/mnt/locust
-    command: -f /mnt/locust/locust-async-issueV1.py --master -H http://host.docker.internal:8080 # coupon-api 에 대한 테스트
+    command: -f /mnt/locust/locust-async-issueV2.py --master -H http://host.docker.internal:8080 # coupon-api 에 대한 테스트
 
   worker:
     image: locustio/locust
     volumes:
       - ./:/mnt/locust
-    command: -f /mnt/locust/locust-async-issueV1.py --worker --master-host master
+    command: -f /mnt/locust/locust-async-issueV2.py --worker --master-host master

--- a/load-test/locust-async-issueV2.py
+++ b/load-test/locust-async-issueV2.py
@@ -2,7 +2,7 @@ import random
 from locust import task, FastHttpUser
 
 
-class CouponIssueAsyncV1(FastHttpUser):
+class CouponIssueAsyncV2(FastHttpUser):
     connection_timeout = 10.0
     network_timeout = 10.0
 
@@ -12,5 +12,5 @@ class CouponIssueAsyncV1(FastHttpUser):
             "userId" : random.randint(1, 100_000_000),
             "couponId" : 1
         }
-        with self.rest("POST", "/coupons/issue/async/v1", json=payload):
+        with self.rest("POST", "/coupons/issue/async/v2", json=payload):
             pass


### PR DESCRIPTION
## Summary

#### 병목 지점을 찾아 분산 락 대신 Redis Script를 사용해 동시성 이슈를 해결하였습니다.
#### rps : 400 -> 800 으로 2배 가까이 성능을 향상시켰습니다.
#### 평균 응답 시간은 절반 이하로 줄었습니다.

<br>

#### 개선 전
![스크린샷 2024-04-18 오전 3 13 21](https://github.com/Jungsu-lilly/First-come-First-served-coupon/assets/56336436/88b05dec-d5fb-4731-8d53-d5eee0ed15ee)


**개선 후**
![스크린샷 2024-04-18 오전 3 12 43](https://github.com/Jungsu-lilly/First-come-First-served-coupon/assets/56336436/7d100280-f787-4a24-8b06-4f6b4d06dd44)

<br>

## Done
- [x] Redis Script를 통해 성능 개선 : I/O 횟수 줄임
- [x] rps 서버 성능 향상